### PR TITLE
update requirements for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,26 @@
 A Windows Desktop app for sorting photos from iCloud into folders.
 
 ## Installation
+### Linux
 ```bash
 python -m venv .venv # or python3 if needed
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+source .venv/bin/activate
 
 pip install -e .
 ```
+
+### Windows
+```bash
+python -m venv .venv # or python3 if needed
+.venv\Scripts\activate
+
+pip install -e --pre .
+```
+Why --pre? This project uses pywebview, which depends on pythonnet on Windows.
+The stable release of pythonnet (v3.0.x) does not support Python 3.14+.
+The --pre flag allows pip to install pythonnet 3.1.0rc0, a pre-release version
+that adds Python 3.14 support. Without it, the install will fail during wheel building.
+
 
 ## Run locally
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ruff>=0.15.6
 pytest>=8.
 pyicloud>=2.4.1
 pywebview>=6.1
+pythonnet>=3.1.0rc0


### PR DESCRIPTION
On Windows pywebview depends on pythonnet.
The stable release of pythonnet (v3.0.x) does not support Python 3.14+.
The --pre flag allows pip to install pythonnet 3.1.0rc0, a pre-release version
that adds Python 3.14 support. Without it, the install will fail during wheel building.